### PR TITLE
Add simple data loading test

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.1 (2025-06-26)
+
+-   **ADD:** Added pytest-based data loading test.
+-   **CHORE:** Included `pytest` in `requirements.txt`.
+
 ## v1.0.0 (2025-06-25)
 
 -   **INIT:** Initialized the project structure.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ The project is divided into the following phases:
 
 A detailed project plan can be found in `plan.md`.
 
+## Tests
+
+Run the test suite with:
+```bash
+pytest
+```
+
 ## Changelog
 
 All changes to the project are documented in `Changelog.md`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ Pygments==2.19.2
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
 pytz==2025.2
+pytest==8.4.0
 pywin32==310
 pyzmq==27.0.0
 scikit-learn==1.7.0

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from pathlib import Path
+
+
+def test_csv_loading():
+    csv_path = Path(__file__).resolve().parents[1] / "data" / "mimic_saaki_final.csv"
+    assert csv_path.is_file(), f"CSV file not found: {csv_path}"
+    df = pd.read_csv(csv_path)
+    assert not df.empty, "Dataframe should have at least one row"
+    assert df.shape[1] > 0, "Dataframe should have at least one column"


### PR DESCRIPTION
## Summary
- add a pytest to verify the CSV file can be loaded
- document running the test suite in the README
- include pytest dependency in requirements
- update changelog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c38f5a9408328a54b1952f345edce